### PR TITLE
✏️ Change GetFileSize to GetFileSizeEx

### DIFF
--- a/src/io_engine_iocp.cpp
+++ b/src/io_engine_iocp.cpp
@@ -710,7 +710,7 @@ namespace asyncpp::io::detail {
 
 	uint64_t io_engine_iocp::file_size(file_handle_t fd) {
 		LARGE_INTEGER file_size{};
-		if (GetFileSizeEx(fd, &size) == FALSE) throw std::system_error(GetLastError(), std::system_category());
+		if (GetFileSizeEx(fd, &file_size) == FALSE) throw std::system_error(GetLastError(), std::system_category());
 		return file_size.QuadPart;
 	}
 

--- a/src/io_engine_iocp.cpp
+++ b/src/io_engine_iocp.cpp
@@ -710,8 +710,7 @@ namespace asyncpp::io::detail {
 
 	uint64_t io_engine_iocp::file_size(file_handle_t fd) {
 		LARGE_INTEGER file_size{};
-		if (GetFileSizeEx(fd, &size) == FALSE)
-			throw std::system_error(GetLastError(), std::system_category());
+		if (GetFileSizeEx(fd, &size) == FALSE) throw std::system_error(GetLastError(), std::system_category());
 		return file_size.QuadPart;
 	}
 

--- a/src/io_engine_iocp.cpp
+++ b/src/io_engine_iocp.cpp
@@ -709,11 +709,10 @@ namespace asyncpp::io::detail {
 	void io_engine_iocp::file_close(file_handle_t fd) { ::CloseHandle(fd); }
 
 	uint64_t io_engine_iocp::file_size(file_handle_t fd) {
-		DWORD high;
-		auto res = GetFileSize(fd, &high);
-		if (res == INVALID_FILE_SIZE && GetLastError() != NO_ERROR)
+		LARGE_INTEGER file_size{};
+		if (GetFileSizeEx(fd, &size) == FALSE)
 			throw std::system_error(GetLastError(), std::system_category());
-		return (static_cast<uint64_t>(high) << 32) + res;
+		return file_size.QuadPart;
 	}
 
 	bool io_engine_iocp::enqueue_readv(file_handle_t fd, void* buf, size_t len, uint64_t offset, completion_data* cd) {


### PR DESCRIPTION
Improve accuracy, compatibility and readability by using the modern GetFileSizeEx API in IOCP implementation of the I/O Engine.